### PR TITLE
update bower/npm dependency to correct base.headings version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,6 @@
   ],
   "license": "Apache",
   "dependencies": {
-    "inuit-headings": "~0.2.2"
+    "inuit-headings": "~0.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "css"
   ],
   "dependencies": {
-    "inuit-headings": "~0.2.2"
+    "inuit-headings": "~0.3.0"
   }
 }


### PR DESCRIPTION
The dependencies are pointing to [version `"~0.2.2"`](https://github.com/inuitcss/base.headings/blob/0.2.2/_base.headings.scss) of [base.headings](https://github.com/inuitcss/base.headings) which is bad, because in that version the abstract `.alpha`, `.beta` etc. classes are still included.
